### PR TITLE
Add webapp skeleton with React & Flask

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,8 @@ A simple XGBoost classifier is used to predict a fighter's performance category 
 ```bash
 pip install playwright xgboost scikit-learn pandas numpy
 playwright install
+```
+
+## Web Application Setup
+
+See [webapp/README.md](webapp/README.md) for instructions on running the React frontend and Flask backend that serve predictions from the trained model.

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -1,0 +1,27 @@
+# Web Application
+
+This directory contains a minimal setup for a React + Vite frontend and a Flask backend.
+
+## Backend
+
+The backend exposes a `/predict` endpoint that loads the trained model from `../Prediction/xgb_ufc_model.pkl` and returns predictions.
+
+To run the backend:
+
+```bash
+cd backend
+pip install -r requirements.txt
+python app.py
+```
+
+## Frontend
+
+The frontend is a simple React application created with Vite. Install dependencies and start the development server:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The app expects the Flask backend to run on `http://localhost:5000`.

--- a/webapp/backend/app.py
+++ b/webapp/backend/app.py
@@ -1,0 +1,21 @@
+from flask import Flask, request, jsonify
+from flask_cors import CORS
+import joblib
+import numpy as np
+import os
+
+app = Flask(__name__)
+CORS(app)
+
+MODEL_PATH = os.path.join(os.path.dirname(__file__), '..', 'Prediction', 'xgb_ufc_model.pkl')
+model = joblib.load(MODEL_PATH)
+
+@app.route('/predict', methods=['POST'])
+def predict():
+    data = request.get_json(force=True)
+    features = np.array(data.get('features')).reshape(1, -1)
+    pred = model.predict(features)[0]
+    return jsonify({'prediction': pred})
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/webapp/backend/requirements.txt
+++ b/webapp/backend/requirements.txt
@@ -1,0 +1,4 @@
+Flask>=3.0.0
+Flask-Cors>=4.0.0
+joblib>=1.3.0
+numpy>=2.0.0

--- a/webapp/frontend/.gitignore
+++ b/webapp/frontend/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.dist
+
+# local env
+.env

--- a/webapp/frontend/index.html
+++ b/webapp/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FightMetricsAI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/webapp/frontend/package.json
+++ b/webapp/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "fightmetrics-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.0.0"
+  }
+}

--- a/webapp/frontend/src/App.css
+++ b/webapp/frontend/src/App.css
@@ -1,0 +1,10 @@
+.App {
+  font-family: Arial, sans-serif;
+  padding: 1rem;
+}
+
+textarea {
+  width: 100%;
+  height: 4rem;
+  margin-bottom: 1rem;
+}

--- a/webapp/frontend/src/App.jsx
+++ b/webapp/frontend/src/App.jsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import './App.css';
+
+function App() {
+  const [inputs, setInputs] = useState('');
+  const [prediction, setPrediction] = useState(null);
+
+  const handleSubmit = async () => {
+    const res = await fetch('http://localhost:5000/predict', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ features: JSON.parse(inputs) })
+    });
+    const data = await res.json();
+    setPrediction(data.prediction);
+  };
+
+  return (
+    <div className="App">
+      <h1>FightMetricsAI</h1>
+      <textarea
+        placeholder="Enter feature array (JSON)"
+        value={inputs}
+        onChange={(e) => setInputs(e.target.value)}
+      />
+      <button onClick={handleSubmit}>Predict</button>
+      {prediction !== null && <div>Prediction: {prediction}</div>}
+    </div>
+  );
+}
+
+export default App;

--- a/webapp/frontend/src/index.css
+++ b/webapp/frontend/src/index.css
@@ -1,0 +1,5 @@
+body {
+  margin: 0;
+  padding: 0;
+  font-family: Arial, sans-serif;
+}

--- a/webapp/frontend/src/main.jsx
+++ b/webapp/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/webapp/frontend/vite.config.js
+++ b/webapp/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- add `webapp` folder with Flask backend and React+Vite frontend
- document how to run the new app
- reference webapp in main README

## Testing
- `python test_pandas.py` *(fails: ModuleNotFoundError for pandas)*

------
https://chatgpt.com/codex/tasks/task_e_685a001dad18832ca9fbefdebfbd095b