### PR TITLE
Add dashboard layout for FightMetricsAI

### DIFF
--- a/webapp/frontend/src/App.css
+++ b/webapp/frontend/src/App.css
@@ -1,10 +1,73 @@
-.App {
-  font-family: Arial, sans-serif;
+.dashboard header {
+  background-color: var(--color-secondary);
+  color: var(--color-third);
+  padding: 1rem;
+  text-align: center;
+}
+
+.main-layout {
+  display: flex;
+  height: calc(100vh - 68px);
+}
+
+.sidebar {
+  background-color: var(--color-primary);
+  width: 200px;
+  padding: 1rem;
+  border-right: 1px solid var(--color-third);
+}
+
+.sidebar ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.sidebar li {
+  margin-bottom: 1rem;
+  cursor: pointer;
+  color: var(--color-third);
+}
+
+.content {
+  flex: 1;
   padding: 1rem;
 }
 
-textarea {
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.card {
+  background-color: var(--color-primary);
+  border: 1px solid var(--color-secondary);
+  border-radius: 8px;
+  padding: 1rem;
+  text-align: center;
+}
+
+.predict-section textarea {
   width: 100%;
   height: 4rem;
+  background-color: var(--color-primary);
+  color: var(--color-third);
+  border: 1px solid var(--color-third);
+  padding: 0.5rem;
   margin-bottom: 1rem;
+}
+
+.predict-section button {
+  background-color: var(--color-secondary);
+  color: var(--color-third);
+  border: none;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+.prediction-result {
+  margin-top: 1rem;
+  font-weight: bold;
 }

--- a/webapp/frontend/src/App.jsx
+++ b/webapp/frontend/src/App.jsx
@@ -6,18 +6,54 @@ function App() {
   const [prediction, setPrediction] = useState(null);
 
   const handleSubmit = async () => {
-    const res = await fetch('http://localhost:5000/predict', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ features: JSON.parse(inputs) })
-    });
-    const data = await res.json();
-    setPrediction(data.prediction);
+    try {
+      const res = await fetch('http://localhost:5000/predict', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ features: JSON.parse(inputs) })
+      });
+      const data = await res.json();
+      setPrediction(data.prediction);
+    } catch (err) {
+      console.error(err);
+    }
   };
 
   return (
-    <div className="App">
-      <h1>FightMetricsAI</h1>
+    <div className="dashboard">
+      <header>
+        <h1>FightMetricsAI Dashboard</h1>
+      </header>
+      <div className="main-layout">
+        <aside className="sidebar">
+          <nav>
+            <ul>
+              <li>Overview</li>
+              <li>Predictions</li>
+              <li>Statistics</li>
+            </ul>
+          </nav>
+        </aside>
+        <main className="content">
+          <section className="cards">
+            <div className="card">Statistic 1</div>
+            <div className="card">Statistic 2</div>
+            <div className="card">Statistic 3</div>
+          </section>
+          <section className="predict-section">
+            <h2>Predict Outcome</h2>
+            <textarea
+              placeholder="[feature1, feature2, ...]"
+              value={inputs}
+              onChange={(e) => setInputs(e.target.value)}
+            />
+            <button onClick={handleSubmit}>Predict</button>
+            {prediction !== null && (
+              <p className="prediction-result">Prediction: {prediction}</p>
+            )}
+          </section>
+        </main>
+      </div>
     </div>
   );
 }

--- a/webapp/frontend/src/index.css
+++ b/webapp/frontend/src/index.css
@@ -1,5 +1,13 @@
+:root {
+  --color-primary: #191923;
+  --color-secondary: #D20A0A;
+  --color-third: #FBFEF9;
+}
+
 body {
   margin: 0;
   padding: 0;
   font-family: Arial, sans-serif;
+  background-color: var(--color-primary);
+  color: var(--color-third);
 }


### PR DESCRIPTION
## Summary
- introduce color scheme variables in index.css
- add modern dashboard layout for the React frontend

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685a0e00fc80832cacf335f53a4e3d77