### PR TITLE
Update predictor section UI

### DIFF
--- a/webapp/frontend/src/App.css
+++ b/webapp/frontend/src/App.css
@@ -70,7 +70,6 @@
   border: none;
   padding: 0.5rem;
   margin-bottom: 1rem;
->>>>>>> e722a9c946e92f607c5a4fbed40423bfe509690c
 }
 
 .predict-section button {
@@ -92,6 +91,47 @@
   margin-top: 1rem;
   font-weight: bold;
   color: var(--color-accent);
+}
+
+/* Align section headers */
+.features h2,
+.predict-section h2 {
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+/* Layout for predictor cards */
+.predict-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.predict-card {
+  background-color: var(--color-secondary);
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+  text-align: center;
+}
+
+.predict-card input {
+  width: 100%;
+  margin-bottom: 0.5rem;
+  padding: 0.5rem;
+  background-color: var(--color-primary);
+  color: var(--color-third);
+  border: none;
+}
+
+.analytics-placeholder {
+  height: 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-accent);
+  border: 2px dashed var(--color-accent);
+  border-radius: 8px;
 }
 
 /* New Landing Page Layout */

--- a/webapp/frontend/src/App.jsx
+++ b/webapp/frontend/src/App.jsx
@@ -2,8 +2,11 @@ import { useState } from 'react';
 import './App.css';
 
 function App() {
+  const [fighterOne, setFighterOne] = useState('');
+  const [fighterTwo, setFighterTwo] = useState('');
   const [inputs, setInputs] = useState('');
   const [prediction, setPrediction] = useState(null);
+  const [nameMessage, setNameMessage] = useState('');
 
   const handleSubmit = async () => {
     try {
@@ -16,6 +19,12 @@ function App() {
       setPrediction(data.prediction);
     } catch (err) {
       console.error(err);
+    }
+  };
+
+  const handleNamePrediction = () => {
+    if (fighterOne && fighterTwo) {
+      setNameMessage(`Prediction for ${fighterOne} vs ${fighterTwo} coming soon`);
     }
   };
 
@@ -56,12 +65,35 @@ function App() {
         </section>
         <section className="predict-section" id="predict">
           <h2>Try the Predictor</h2>
+          <div className="predict-cards">
+            <div className="predict-card">
+              <h3>Live Fight Prediction</h3>
+              <input
+                placeholder="Fighter One"
+                value={fighterOne}
+                onChange={(e) => setFighterOne(e.target.value)}
+              />
+              <input
+                placeholder="Fighter Two"
+                value={fighterTwo}
+                onChange={(e) => setFighterTwo(e.target.value)}
+              />
+              <button onClick={handleNamePrediction}>Predict</button>
+              {nameMessage && (
+                <p className="prediction-result">{nameMessage}</p>
+              )}
+            </div>
+            <div className="predict-card">
+              <h3>Analytics</h3>
+              <div className="analytics-placeholder">Charts Coming Soon</div>
+            </div>
+          </div>
           <textarea
             placeholder="[feature1, feature2, ...]"
             value={inputs}
             onChange={(e) => setInputs(e.target.value)}
           />
-          <button onClick={handleSubmit}>Predict</button>
+          <button onClick={handleSubmit}>Predict from Features</button>
           {prediction !== null && (
             <p className="prediction-result">Prediction: {prediction}</p>
           )}


### PR DESCRIPTION
## Summary
- clean leftover merge marker
- align Predict header with Features heading
- add predictor cards: live fight inputs and analytics placeholder
- keep feature-based prediction area

## Testing
- `python3 test_pandas.py`

------
https://chatgpt.com/codex/tasks/task_e_685ab3d8931c832c85c9aa9728b8a560