### PR TITLE
Add styling and layout tweaks

### DIFF
--- a/webapp/frontend/src/App.css
+++ b/webapp/frontend/src/App.css
@@ -113,6 +113,8 @@
   padding: 1rem;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
   text-align: center;
+  min-height: 320px;
+  margin-bottom: 2rem;
 }
 
 .predict-card input {
@@ -122,6 +124,35 @@
   background-color: var(--color-primary);
   color: var(--color-third);
   border: none;
+}
+
+.fighter-selection {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.fighter-input {
+  flex: 1;
+  text-align: center;
+}
+
+.fighter-input input {
+  width: 90%;
+}
+
+.fighter-image {
+  width: 100%;
+  height: 150px;
+  background-color: #2b2b2b;
+  border-radius: 4px;
+  margin-bottom: 0.5rem;
+}
+
+.vs {
+  margin: 0 0.5rem;
+  font-weight: bold;
 }
 
 .analytics-placeholder {

--- a/webapp/frontend/src/App.jsx
+++ b/webapp/frontend/src/App.jsx
@@ -68,20 +68,37 @@ function App() {
           <div className="predict-cards">
             <div className="predict-card left-card">
               <h3>Live Fight Prediction</h3>
-              <input
-                placeholder="Fighter One"
-                value={fighterOne}
-                onChange={(e) => setFighterOne(e.target.value)}
-              />
-              <input
-                placeholder="Fighter Two"
-                value={fighterTwo}
-                onChange={(e) => setFighterTwo(e.target.value)}
-              />
+              <div className="fighter-selection">
+                <div className="fighter-input">
+                  <div className="fighter-image"></div>
+                  <input
+                    list="fighter-options"
+                    placeholder="Fighter One"
+                    value={fighterOne}
+                    onChange={(e) => setFighterOne(e.target.value)}
+                  />
+                </div>
+                <span className="vs">vs</span>
+                <div className="fighter-input">
+                  <div className="fighter-image"></div>
+                  <input
+                    list="fighter-options"
+                    placeholder="Fighter Two"
+                    value={fighterTwo}
+                    onChange={(e) => setFighterTwo(e.target.value)}
+                  />
+                </div>
+              </div>
               <button onClick={handleNamePrediction}>Predict</button>
               {nameMessage && (
                 <p className="prediction-result">{nameMessage}</p>
               )}
+              <datalist id="fighter-options">
+                <option value="Conor McGregor" />
+                <option value="Khabib Nurmagomedov" />
+                <option value="Jon Jones" />
+                <option value="Israel Adesanya" />
+              </datalist>
             </div>
             <div className="predict-card">
               <h3>Analytics</h3>


### PR DESCRIPTION
## Summary
- extend predictor cards and add margin at bottom
- lay out fighter selection side-by-side with placeholder images
- add searchable datalist for fighters
- update CSS for new selection layout

## Testing
- `npm run build`
- `python test_pandas.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685ac41d8514832c9fcc9e205df82277