### PR TITLE
Tame accent color

### DIFF
--- a/webapp/frontend/src/index.css
+++ b/webapp/frontend/src/index.css
@@ -1,9 +1,9 @@
 :root {
-  /* Updated color scheme */
+  /* Updated color scheme with muted accent */
   --color-primary: #0C120C;
-  --color-secondary: #C20114;
+  --color-secondary: #1e1e1e;
   --color-third: #C7D6D5;
-  --color-accent: var(--color-secondary);
+  --color-accent: #b34345;
 }
 
 body {


### PR DESCRIPTION
## Summary
- tone down red by using a muted accent color in the CSS variables

## Testing
- `pip install pandas`
- `pytest -q`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ace71cdb4832c8a368d8a2fbdffa3