### PR TITLE
Add animated canvas hero background

### DIFF
--- a/webapp/frontend/src/App.css
+++ b/webapp/frontend/src/App.css
@@ -186,6 +186,17 @@
 .site-header .logo {
   font-weight: 600;
   font-size: 1.5rem;
+  display: flex;
+  align-items: center;
+}
+
+.logo-icon {
+  display: inline-block;
+  width: 24px;
+  height: 24px;
+  margin-left: 0.5rem;
+  background-color: var(--color-accent);
+  border-radius: 4px;
 }
 
 .site-header ul {
@@ -207,9 +218,26 @@
 }
 
 .hero {
+  position: relative;
   text-align: center;
   padding: 4rem 2rem;
   background: linear-gradient(135deg, var(--color-secondary), var(--color-primary));
+  overflow: hidden;
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
+}
+
+.decision-canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 0;
 }
 
 .hero h1 {

--- a/webapp/frontend/src/App.jsx
+++ b/webapp/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import './App.css';
 
 function App() {
@@ -7,6 +7,67 @@ function App() {
   const [inputs, setInputs] = useState('');
   const [prediction, setPrediction] = useState(null);
   const [nameMessage, setNameMessage] = useState('');
+
+  useEffect(() => {
+    const canvas = document.getElementById('decision-canvas');
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    let animationFrame;
+
+    function resize() {
+      canvas.width = canvas.offsetWidth;
+      canvas.height = canvas.offsetHeight;
+    }
+
+    window.addEventListener('resize', resize);
+    resize();
+
+    const nodes = Array.from({ length: 6 }, () => ({
+      x: Math.random() * canvas.width,
+      y: Math.random() * canvas.height,
+      vx: 0.5 + Math.random(),
+      value: (50 + Math.random() * 50).toFixed(1),
+    }));
+
+    function draw() {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.strokeStyle = 'rgba(255,255,255,0.3)';
+      ctx.fillStyle = 'rgba(255,255,255,0.8)';
+
+      nodes.forEach((node, idx) => {
+        node.x += node.vx;
+        if (node.x > canvas.width + 50) {
+          node.x = -50;
+          node.y = Math.random() * canvas.height;
+          node.vx = 0.5 + Math.random();
+          node.value = (50 + Math.random() * 50).toFixed(1);
+        }
+        if (idx < nodes.length - 1) {
+          ctx.beginPath();
+          ctx.moveTo(node.x, node.y);
+          ctx.lineTo(nodes[idx + 1].x, nodes[idx + 1].y);
+          ctx.stroke();
+        }
+      });
+
+      nodes.forEach((node) => {
+        ctx.beginPath();
+        ctx.arc(node.x, node.y, 5, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.stroke();
+        ctx.fillText(`${node.value}%`, node.x + 8, node.y + 3);
+      });
+
+      animationFrame = requestAnimationFrame(draw);
+    }
+
+    draw();
+
+    return () => {
+      window.removeEventListener('resize', resize);
+      cancelAnimationFrame(animationFrame);
+    };
+  }, []);
 
   const handleSubmit = async () => {
     try {
@@ -31,7 +92,7 @@ function App() {
   return (
     <div className="app">
       <header className="site-header">
-        <div className="logo">FightMetricsAI</div>
+        <div className="logo">FightMetricsAI<span className="logo-icon" /></div>
         <nav>
           <ul>
             <li><a href="#features">Features</a></li>
@@ -42,9 +103,12 @@ function App() {
       </header>
       <main>
         <section className="hero">
-          <h1>Unlock Fight Insights</h1>
-          <p>Use AI-driven analytics to analyze UFC stats and predict outcomes.</p>
-          <a className="cta-button" href="#predict">Get Started</a>
+          <canvas id="decision-canvas" className="decision-canvas"></canvas>
+          <div className="hero-content">
+            <h1>Unlock Fight Insights</h1>
+            <p>Use AI-driven analytics to analyze UFC stats and predict outcomes.</p>
+            <a className="cta-button" href="#predict">Get Started</a>
+          </div>
         </section>
         <section className="features" id="features">
           <h2>Features</h2>


### PR DESCRIPTION
## Summary
- add decision tree animation with canvas
- add placeholder logo icon
- style hero section for moving canvas effect

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685ad26f3124832c9c959b82c03e30f9