### PR TITLE
Revert tree density for smoother loop

### DIFF
--- a/webapp/frontend/src/App.jsx
+++ b/webapp/frontend/src/App.jsx
@@ -33,40 +33,30 @@ function App() {
       'Ground Control',
     ];
 
-    function generateTree() {
-      const levels = 7; // deeper tree for a grand look
-      const tree = [];
-      for (let level = 0; level < levels; level++) {
-        const count = Math.pow(2, level);
-        const levelNodes = [];
-        const baseY = (canvas.height / (levels + 1)) * (level + 1);
-        for (let i = 0; i < count; i++) {
-          levelNodes.push({
-            x:
-              (canvas.width / (count + 1)) * (i + 1) +
-              (Math.random() - 0.5) * (canvas.width / (count + 2)),
-            y:
-              baseY + (Math.random() - 0.5) * (canvas.height / (levels + 2)),
-            value: (50 + Math.random() * 50).toFixed(1),
-            title: titles[Math.floor(Math.random() * titles.length)],
-          });
-        }
-        tree.push(levelNodes);
+    const levels = 5; // depth of the tree
+    const tree = [];
+    for (let level = 0; level < levels; level++) {
+      const count = Math.pow(2, level);
+      const levelNodes = [];
+      for (let i = 0; i < count; i++) {
+        levelNodes.push({
+          x: (canvas.width / (count + 1)) * (i + 1),
+          y: (canvas.height / (levels + 1)) * (level + 1),
+          value: (50 + Math.random() * 50).toFixed(1),
+          title: titles[Math.floor(Math.random() * titles.length)],
+        });
       }
-
-      const edges = [];
-      for (let level = 1; level < levels; level++) {
-        const parentLevel = tree[level - 1];
-        const currentLevel = tree[level];
-        for (let i = 0; i < currentLevel.length; i++) {
-          const parent = parentLevel[Math.floor(Math.random() * parentLevel.length)];
-          edges.push([parent, currentLevel[i]]);
-        }
-      }
-      return { tree, edges, levels };
+      tree.push(levelNodes);
     }
 
-    let { tree, edges } = generateTree();
+    const edges = [];
+    for (let level = 1; level < levels; level++) {
+      const parentLevel = tree[level - 1];
+      const currentLevel = tree[level];
+      for (let i = 0; i < currentLevel.length; i++) {
+        edges.push([parentLevel[Math.floor(i / 2)], currentLevel[i]]);
+      }
+    }
 
     let offset = 0;
     const speed = 0.5;
@@ -95,10 +85,7 @@ function App() {
       ctx.fillStyle = 'rgba(255,255,255,0.8)';
 
       offset += speed;
-      if (offset > canvas.width) {
-        offset = 0;
-        ({ tree, edges } = generateTree());
-      }
+      if (offset > canvas.width) offset = 0;
 
       drawTree(offset);
       drawTree(offset - canvas.width);


### PR DESCRIPTION
## Summary
- revert decision tree animation to previous density

## Testing
- `python test_pandas.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685adb9d76a4832ca96989fff35109af