### PR TITLE
Adjust network connections and lighten hero overlay

### DIFF
--- a/webapp/frontend/src/App.css
+++ b/webapp/frontend/src/App.css
@@ -232,7 +232,8 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0, 0, 0, 0.4);
+  /* Make the hero background slightly more vibrant */
+  background: rgba(0, 0, 0, 0.3);
   z-index: 1;
   pointer-events: none;
 }

--- a/webapp/frontend/src/App.jsx
+++ b/webapp/frontend/src/App.jsx
@@ -49,7 +49,8 @@ function App() {
 
     const edges = [];
     nodes.forEach((from) => {
-      const connectionCount = 2 + Math.floor(Math.random() * 3); // 2-4 connections
+      // Slightly reduce the number of edges created between nodes
+      const connectionCount = 1 + Math.floor(Math.random() * 3); // 1-3 connections
       for (let i = 0; i < connectionCount; i++) {
         let to = nodes[Math.floor(Math.random() * numNodes)];
         if (to === from) continue;


### PR DESCRIPTION
## Summary
- reduce connections per node in the hero network animation
- lighten the hero overlay for a slightly brighter background

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685adf5be310832c9d453fbbe1f8f051