### PR TITLE
Improve node spacing in network canvas

### DIFF
--- a/webapp/frontend/src/App.jsx
+++ b/webapp/frontend/src/App.jsx
@@ -36,11 +36,22 @@ function App() {
     const shapes = ['circle', 'square', 'triangle'];
     const numNodes = 30;
     const nodes = [];
+    const minDistance = 60; // keep nodes spaced so labels don't overlap
 
     for (let i = 0; i < numNodes; i++) {
+      let x, y, attempts = 0;
+      do {
+        x = Math.random() * canvas.width;
+        y = Math.random() * canvas.height;
+        attempts++;
+      } while (
+        attempts < 100 &&
+        nodes.some((n) => Math.hypot(n.x - x, n.y - y) < minDistance)
+      );
+
       nodes.push({
-        x: Math.random() * canvas.width,
-        y: Math.random() * canvas.height,
+        x,
+        y,
         value: (50 + Math.random() * 50).toFixed(1),
         title: titles[Math.floor(Math.random() * titles.length)],
         shape: shapes[i % shapes.length],


### PR DESCRIPTION
## Summary
- prevent nodes from overlapping when generating the network

## Testing
- `python test_pandas.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685ae0100f88832c96f7b18f4a50b2c5