### PR TITLE
Fix backend prediction endpoint

### DIFF
--- a/webapp/backend/app.py
+++ b/webapp/backend/app.py
@@ -43,11 +43,15 @@ def predict():
     print('Fighter One ID:', fighter_one_id)
     print('Fighter Two ID:', fighter_two_id)
 
-    winner = getCustomPredict(fighter_one_id, fighter_two_id)
-    print('Winner: ' + winner)
+    winner_id, confidence = getCustomPredict(fighter_one_id, fighter_two_id)
 
+    if winner_id is None:
+        return jsonify({'error': 'Unable to determine winner'}), 400
 
-    return jsonify({'message': 'Names received'})
+    winner_row = df[df['id'] == winner_id]
+    winner_name = winner_row['name'].iloc[0] if not winner_row.empty else str(winner_id)
+
+    return jsonify({'prediction': winner_name, 'confidence': confidence})
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/webapp/backend/custom_inputs.py
+++ b/webapp/backend/custom_inputs.py
@@ -1,12 +1,14 @@
 import joblib
+import os
 import pandas as pd
 
-# Load the model
-model = joblib.load("xgb_ufc_model.pkl")
+# Load the model located in the same directory as this file
+MODEL_PATH = os.path.join(os.path.dirname(__file__), "xgb_ufc_model.pkl")
+model = joblib.load(MODEL_PATH)
 
-# Read in up-to-date dataset
-df = pd.read_csv("../Data/scraped-ufc-data.csv", sep=';')
-print(df.columns)
+# Read in up-to-date dataset that ships with the backend
+DATA_PATH = os.path.join(os.path.dirname(__file__), "scraped-ufc-data.csv")
+df = pd.read_csv(DATA_PATH, sep=';')
 
 # helper function to clean data to match ML dataset
 def height_str_to_cm(height_str):
@@ -17,13 +19,6 @@ def height_str_to_cm(height_str):
         return int(feet * 30.48 + inches * 2.54)
     except:
         return None  # or 0, or raise an error
-
-# Example usage
-print(height_str_to_cm("6' 3\""))   # ➜ 190
-print(height_str_to_cm("5' 11\""))  # ➜ 180
-
-# fighter1name = ''
-# fighter2name = ''
 
 # enter fighter ids ex: calcdiff(64, 22)
 def getCustomPredict(fighter1, fighter2):
@@ -63,11 +58,15 @@ def getCustomPredict(fighter1, fighter2):
     p1 = model.predict_proba(X1)[0][1]  # prob f1 wins
     p2 = model.predict_proba(X2)[0][1]  # prob f2 wins (if f2 was first)
 
-    # Choose the higher confidence direction
+    # Choose the higher confidence direction and return the winner id and probability
     if p1 >= p2:
-        print(f"Predicted Winner: Fighter {fighter1} (ID {fighter1}) — Confidence: {p1:.2f}")
+        winner_id = fighter1
+        confidence = float(p1)
     else:
-        print(f"Predicted Winner: Fighter {fighter2} (ID {fighter2}) — Confidence: {p2:.2f}")
+        winner_id = fighter2
+        confidence = float(p2)
+
+    return winner_id, confidence
 
 
 


### PR DESCRIPTION
## Summary
- correct backend data/model paths
- implement `getCustomPredict` return values
- update prediction API to return winner name and probability

## Testing
- `python test_pandas.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685c8e755304832c9fad9e3d1fb939df