### PR TITLE
Replace red square with placeholder logo

### DIFF
--- a/webapp/frontend/img/logo-placeholder.svg
+++ b/webapp/frontend/img/logo-placeholder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#ddd" stroke="#999" stroke-width="2" />
+  <text x="32" y="35" font-size="14" text-anchor="middle" fill="#555" font-family="sans-serif">Logo</text>
+</svg>

--- a/webapp/frontend/src/App.css
+++ b/webapp/frontend/src/App.css
@@ -192,11 +192,10 @@
 
 .logo-icon {
   display: inline-block;
-  width: 24px;
-  height: 24px;
-  margin-left: 0.5rem;
-  background-color: var(--color-accent);
-  border-radius: 4px;
+  width: 32px;
+  height: 32px;
+  margin-right: 0.5rem;
+  object-fit: contain;
 }
 
 .site-header ul {

--- a/webapp/frontend/src/App.jsx
+++ b/webapp/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import './App.css';
+import logoPlaceholder from '../img/logo-placeholder.svg';
 
 function App() {
   const [fighterOne, setFighterOne] = useState('');
@@ -145,7 +146,10 @@ function App() {
   return (
     <div className="app">
       <header className="site-header">
-        <div className="logo">FightMetricsAI<span className="logo-icon" /></div>
+        <div className="logo">
+          <img src={logoPlaceholder} alt="Logo" className="logo-icon" />
+          FightMetricsAI
+        </div>
         <nav>
           <ul>
             <li><a href="#features">Features</a></li>


### PR DESCRIPTION
## Summary
- provide placeholder logo image
- import and display the placeholder image in header
- adjust header icon styling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685c94b724b0832c9e916a7e47a7e194