### PR TITLE
Implement MMA math model scoring

### DIFF
--- a/Prediction/ufc_predict_math.py
+++ b/Prediction/ufc_predict_math.py
@@ -18,6 +18,7 @@
 
 
 import pandas as pd
+from typing import Optional
 
 # Implemented Math Model --
 
@@ -32,21 +33,21 @@ import pandas as pd
 
 rankWinMap = {
     "chmp": 16,
-    "1" : 15,
-    "2" : 14,
-    "3" : 13,
-    "4" : 12,
-    "5" : 11,
-    "6" : 10,
-    "7" : 9,
-    "8" : 8,
-    "9" : 7,
-    "10" : 6,
-    "11" : 5,
-    "12" : 4,
-    "13" : 3,
-    "14" : 2,
-    "15" : 1              
+    "1": 15,
+    "2": 14,
+    "3": 13,
+    "4": 12,
+    "5": 11,
+    "6": 10,
+    "7": 9,
+    "8": 8,
+    "9": 7,
+    "10": 6,
+    "11": 5,
+    "12": 4,
+    "13": 3,
+    "14": 2,
+    "15": 1,
 }
 
 
@@ -63,13 +64,111 @@ winMap = {
 
 #   - Relative Victories:
     #   1. beat someone who beat opponent: +5 pts / 1 pt if loss was avenged by other fighter
-        # - +5 additional pts if finish, +1 for each ina  finish streak
+        # - +5 additional pts if finish, +1 for each in a finish streak
 
 
+def _get_last_fights(df: pd.DataFrame, fighter_id: int, last_n: int = 5) -> pd.DataFrame:
+    """Return the last ``last_n`` fights for ``fighter_id`` sorted by most recent."""
+    fighter_df = df[df["fighter_id"] == fighter_id]
+    if "date" in fighter_df.columns:
+        fighter_df = fighter_df.sort_values("date", ascending=False)
+    return fighter_df.head(last_n)
 
 
-def mathmodel(fighter1id, fighter2id):
-    pass
+def _base_score(last_fights: pd.DataFrame) -> int:
+    """Calculate the base MMA Math score from a fighter's last fights."""
+    score = 0
+    finish_streak = 0
+
+    for _, row in last_fights.iterrows():
+        result = row.get("result", "")
+        method = str(row.get("method", "")).lower()
+
+        if result == "Win":
+            rank = row.get("opponent_rank")
+            champ = row.get("opponent_is_champ", False)
+            if champ:
+                score += rankWinMap["chmp"]
+            elif pd.notna(rank) and str(int(rank)) in rankWinMap:
+                score += rankWinMap[str(int(rank))]
+
+            if method and method != "decision":
+                finish_streak += 1
+                score += winMap["finish"] + winMap["finishStreak1x"] * finish_streak
+            else:
+                finish_streak = 0
+
+            if row.get("two_judges_all_rounds"):
+                score += winMap["2judgesWin"]
+        elif result == "Loss":
+            finish_streak = 0
+            if method and method != "decision":
+                score -= 3
+            else:
+                score -= 2
+        else:
+            finish_streak = 0
+
+    # Bonus rules
+    if not last_fights.empty:
+        age = last_fights.iloc[0].get("fighter_age")
+        if pd.notna(age) and age > 35:
+            score -= 5 + int(age - 35)
+
+    if last_fights.shape[0] and (last_fights["result"] != "Loss").all():
+        score += 3
+
+    return score
+
+
+def _relative_victory_score(df: pd.DataFrame, fighter_a: int, fighter_b: int, last_n: int = 5) -> int:
+    """Return bonus points for fighter_a for relative victories over fighter_b."""
+    a_fights = _get_last_fights(df, fighter_a, last_n)
+    b_fights = _get_last_fights(df, fighter_b, last_n)
+
+    score = 0
+    for _, row in a_fights[a_fights["result"] == "Win"].iterrows():
+        opp = row.get("opponent_id")
+        if pd.isna(opp):
+            continue
+
+        losses_to_opp = b_fights[(b_fights["opponent_id"] == opp) & (b_fights["result"] == "Loss")]
+        if not losses_to_opp.empty:
+            avenged = b_fights[(b_fights["opponent_id"] == opp) & (b_fights["result"] == "Win") & (b_fights.index > losses_to_opp.index[0])]
+            base = 1 if not avenged.empty else 5
+            if str(row.get("method", "")).lower() != "decision":
+                base += winMap["finish"]
+                base += winMap["finishStreak1x"] * max(int(row.get("finish_streak", 1)) - 1, 0)
+            score += base
+
+    return score
+
+
+def mathmodel(df: pd.DataFrame, fighter_id: int, opponent_id: Optional[int] = None, last_n: int = 5) -> int:
+    """Calculate the MMA Math score for ``fighter_id``.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        DataFrame containing fight history. Required columns:
+        ``fighter_id``, ``opponent_id``, ``result``, ``method``, ``date`` and
+        ``opponent_rank`` or ``opponent_is_champ``.
+    fighter_id : int
+        Fighter whose score to compute.
+    opponent_id : int, optional
+        If provided, relative victory points against ``opponent_id`` are
+        included in the result.
+    last_n : int, default ``5``
+        Number of most recent fights to consider.
+    """
+
+    last_fights = _get_last_fights(df, fighter_id, last_n)
+    score = _base_score(last_fights)
+
+    if opponent_id is not None:
+        score += _relative_victory_score(df, fighter_id, opponent_id, last_n)
+
+    return score
 
 
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ pip install playwright xgboost scikit-learn pandas numpy
 playwright install
 ```
 
+
+### MMA Math Model
+
+The project includes a Python implementation of the "MMA Math" algorithm.
+Call `prediction.ufc_predict_math.mathmodel(df, fighter_id, opponent_id=None)`
+to score a fighter using only their last five fights. Passing an `opponent_id`
+adds relative-victory bonuses that compare both fighters' recent opponents.
+
 ## Web Application Setup
 
 See [webapp/README.md](webapp/README.md) for instructions on running the React frontend and Flask backend that serve predictions from the trained model.


### PR DESCRIPTION
## Summary
- implement functions for MMA math model scoring
- add optional relative victory bonus when fighters are matched
- document usage of the MMA math model in README

## Testing
- `python test_pandas.py`

------
https://chatgpt.com/codex/tasks/task_e_686e1119fb78832cab93f7ae578bd8d5