### PR TITLE
Limit scraper to last five fights

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ The script collects general and career-specific stats for each fighter by naviga
   - Strikes Absorbed per Minute (SApM)
   - Striking Defense
   - Takedown Average, Accuracy, Defense
-  - Submission Average
+- Submission Average
+- For each fighter's **last five UFC bouts**:
+  - Opponent name and ranking (or champion status)
+  - Fight result and method of victory
+  - Event date, location and whether judges gave all rounds
 
 ### Additional Data
 
@@ -132,6 +136,8 @@ You need to gather the following fields per fight per fighter:
 Opponent name
 
 Opponent UFC rank at time of fight (0 = Champion, 1 = #1, etc.)
+
+Whether the bout was a title fight (opponent entering as champion)
 
 Win or loss?
 

--- a/UFC-scrape/ufc_scrape2.py
+++ b/UFC-scrape/ufc_scrape2.py
@@ -182,13 +182,33 @@ def parse_recent_fights(profile_page):
             except Exception:
                 traceback.print_exc()
 
+            # --- scrape fight details for ranking and title info ---
+            opponent_rank = None
+            opponent_is_champ = False
+            try:
+                fight_link_el = cells[1].query_selector("a")
+                fight_link = fight_link_el.get_attribute("href") if fight_link_el else None
+                if fight_link:
+                    fight_page = profile_page.context.new_page()
+                    fight_page.goto(fight_link, timeout=10000)
+                    fight_page.wait_for_selector("body", timeout=5000)
+                    body_text = fight_page.inner_text("body").lower()
+                    if "title fight" in body_text or "championship" in body_text:
+                        opponent_is_champ = True
+                    rank_match = re.search(r"rank[^\d]*(\d+)", body_text)
+                    if rank_match:
+                        opponent_rank = int(rank_match.group(1))
+                    fight_page.close()
+            except Exception:
+                traceback.print_exc()
+
             fights.append(
                 {
                     "result": result_text,
                     "method": method,
                     "opponent": opponent_name,
-                    "opponent_rank": None,
-                    "opponent_is_champ": False,
+                    "opponent_rank": opponent_rank,
+                    "opponent_is_champ": opponent_is_champ,
                     "all_rounds_judges": all_rounds,
                     "location_country": location_country,
                     "date": fight_date,


### PR DESCRIPTION
## Summary
- include last five fight details (opponent rank/champion status) in the scraper output
- document fight detail scraping in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ec31076cc832cb5da545715ff8a1c